### PR TITLE
Fix CSV writer function - final cleanup

### DIFF
--- a/sensorloader_trt.py
+++ b/sensorloader_trt.py
@@ -226,18 +226,8 @@ def write_to_neo4j_csv(data, filename='data/live_readings.csv'):
         if not file_exists:
             writer.writeheader()
         
-        # Write data row
- 
-        
-        writer.writerow({
-            'timestamp': timestamp,
-            'temperature': data['raw']['temperature'],
-            'humidity': data['raw']['humidity'],
-            'pressure': data['raw']['pressure'],
-            'gas': data['raw']['gas_resistance'],
-            'validity_score': data['filtered']['validity_score']
-        })
-
+        # Write data row using the prepared dictionary
+        writer.writerow(row_data)
 
 def main():
     # Initialize sensor


### PR DESCRIPTION
This PR fixes the remaining issues with the `write_to_neo4j_csv` function. After the previous merge, there were still some problems:

1. The function contained a duplicate `writer.writerow()` call - one using the prepared `row_data` dictionary and another using the problematic inline dictionary construction
2. The problematic inline dictionary still had the bracket syntax error

This PR:
1. Removes the duplicated `writer.writerow()` call
2. Ensures only the working implementation using the separately prepared `row_data` dictionary is used

This should fix the remaining issues with the Neo4j CSV writer and allow the sensor loader to run properly.
